### PR TITLE
Properly escapes the double quote character in command sent to `tmux

### DIFF
--- a/lib/JumpScale/baselib/screen/Tmux.py
+++ b/lib/JumpScale/baselib/screen/Tmux.py
@@ -52,6 +52,9 @@ class Tmux:
         for name, value in list(env.items()):
             envstr += "export %s=%s\n" % (name, value)
 
+        # Escape the double quote character in cmd
+        cmd = cmd.replace('"', r'\"')
+
         if cmd.strip():
             self.createWindow(sessionname, screenname,user=tmuxuser)
             pane = self._getPane(sessionname, screenname,user=tmuxuser)


### PR DESCRIPTION
send-keys`.